### PR TITLE
Implement generic network layer for photo service

### DIFF
--- a/Vodafone Task/Vodafone Task/API/NetworkService.swift
+++ b/Vodafone Task/Vodafone Task/API/NetworkService.swift
@@ -5,9 +5,31 @@ struct NetworkService {
     static func fetchData<T: Decodable>(router: APIRouter,
                                         decoder: JSONDecoder = JSONDecoder(),
                                         completion: @escaping(Result<T, Error>) -> Void) {
+        do {
+            let request = try router.asURLRequest()
+            let urlString = request.url?.absoluteString ?? "Unknown URL"
+            var parametersDescription = ""
+            if let httpBody = request.httpBody,
+               let bodyString = String(data: httpBody, encoding: .utf8) {
+                parametersDescription = bodyString
+            } else if let url = request.url,
+                      let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.query {
+                parametersDescription = query
+            }
+            debugPrint("[NetworkService] URL: \(urlString)")
+            debugPrint("[NetworkService] Parameters: \(parametersDescription)")
+        } catch {
+            debugPrint("[NetworkService] Failed to build request: \(error)")
+        }
+
         AF.request(router)
             .validate()
             .responseData { response in
+                debugPrint("[NetworkService] Status Code: \(response.response?.statusCode ?? -1)")
+                if let data = response.data,
+                   let bodyString = String(data: data, encoding: .utf8) {
+                    debugPrint("[NetworkService] Response Body: \(bodyString)")
+                }
                 switch response.result {
                 case .success(let data):
                     do {

--- a/Vodafone Task/Vodafone Task/API/NetworkService.swift
+++ b/Vodafone Task/Vodafone Task/API/NetworkService.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Alamofire
+
+struct NetworkService {
+    static func fetchData<T: Decodable>(router: APIRouter,
+                                        decoder: JSONDecoder = JSONDecoder(),
+                                        completion: @escaping(Result<T, Error>) -> Void) {
+        AF.request(router)
+            .validate()
+            .responseData { response in
+                switch response.result {
+                case .success(let data):
+                    do {
+                        let object = try decoder.decode(T.self, from: data)
+                        completion(.success(object))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+    }
+}

--- a/Vodafone Task/Vodafone Task/Moduls/Photos/Services/PhotosService.swift
+++ b/Vodafone Task/Vodafone Task/Moduls/Photos/Services/PhotosService.swift
@@ -6,26 +6,18 @@
 //
 
 import Foundation
-import  Alamofire
 
 class PhotosService: PhotosServiceProtocol {
     func getPhotossService(page:Int,success: @escaping ([PhotosModel]) -> (), failure: @escaping () -> ()) {
-   
-        AF.request(APIRouter.getPhotos(page:page))
-            .responseJSON(completionHandler: { (resp) in
-                print("Get recipes \(resp)")
-            })
-            .responseDecodable {  (response: DataResponse<[PhotosModel], AFError>) in
-                switch response.result {
-                    
-                case .success(let data):
-                    
-                    success(data)
 
-                case .failure(let err):
-                    print(err)
-                    print("Get My Answer Failure")
-                }
+        NetworkService.fetchData(router: .getPhotos(page: page)) { (result: Result<[PhotosModel], Error>) in
+            switch result {
+            case .success(let data):
+                success(data)
+            case .failure(let error):
+                print(error)
+                failure()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add a generic `NetworkService` for API requests
- refactor `PhotosService` to use the new network layer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857e1dd7e4c832aa6afebe5a7885e11